### PR TITLE
Fix minimum fee validation for Verium

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -25,7 +25,7 @@ CAmount CFeeRate::GetFee(size_t nBytes_) const
     assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
     int64_t nSize = int64_t(nBytes_);
 
-    CAmount nFee = nSatoshisPerK * nSize / 1000;
+    CAmount nFee = nSatoshisPerK * (1 + nSize / 1000);
 
     if (nFee == 0 && nSize != 0) {
         if (nSatoshisPerK > 0)


### PR DESCRIPTION
Verium calculates the minimum fee slightly differently from Bitcoin. Instead of baseFee*size it uses baseFee*(1+size).